### PR TITLE
RigidBody Fix

### DIFF
--- a/Bullet_script.gd
+++ b/Bullet_script.gd
@@ -41,7 +41,7 @@ func collided(body):
 	# If it does, then call it, passing our global origin as the bullet collision point.
 	if hit_something == false:
 		if body.has_method("bullet_hit"):
-			body.bullet_hit(BULLET_DAMAGE, self.global_transform.origin)
+			body.bullet_hit(BULLET_DAMAGE, global_transform)
 	
 	# Set hit_something to true because we've hit an object and set free ourself.
 	hit_something = true

--- a/Grenade.gd
+++ b/Grenade.gd
@@ -56,7 +56,7 @@ func _process(delta):
 			var bodies = blast_area.get_overlapping_bodies()
 			for body in bodies:
 				if body.has_method("bullet_hit"):
-					body.bullet_hit(GRENADE_DAMAGE, global_transform.origin)
+					body.bullet_hit(GRENADE_DAMAGE, body.global_transform.looking_at(global_transform.origin, Vector3(0,1,0)) )
 			
 			# This would be the perfect place to play a sound!
 		

--- a/Player.gd
+++ b/Player.gd
@@ -775,7 +775,7 @@ func add_grenade(additional_grenade):
 	grenade_amounts[current_grenade] = clamp(grenade_amounts[current_grenade], 0, 4)
 
 
-func bullet_hit(damage, bullet_hit_pos):
+func bullet_hit(damage, bullet_global_transform):
 	# Removes damage from our health
 	health -= damage
 

--- a/RigidBody_hit_test.gd
+++ b/RigidBody_hit_test.gd
@@ -1,14 +1,11 @@
 extends RigidBody
 
+const BASE_BULLET_BOOST = 9;
+
 func _ready():
 	pass
 
-func bullet_hit(damage, bullet_hit_pos):
-	# We get the directional vector pointing from the bullet hit position to our origin.
-	var direction_vect = global_transform.origin - bullet_hit_pos
-	# Normalize the directional vector (so distance doesn't change the knockback)
-	direction_vect = direction_vect.normalized()
+func bullet_hit(damage, bullet_global_trans):
+	var direction_vect = bullet_global_trans.basis.z.normalized() * BASE_BULLET_BOOST;
 	
-	# Then we apply a local impulse at the hit position with a force pointed at the directional vector.
-	# This gives the appearance of the bullet push the object on collision.
-	apply_impulse(bullet_hit_pos, direction_vect * damage)
+	apply_impulse((bullet_global_trans.origin - global_transform.origin).normalized(), direction_vect * damage)

--- a/StickyGrenade.gd
+++ b/StickyGrenade.gd
@@ -102,7 +102,7 @@ func _process(delta):
 			var bodies = blast_area.get_overlapping_bodies()
 			for body in bodies:
 				if body.has_method("bullet_hit"):
-					body.bullet_hit(GRENADE_DAMAGE, global_transform.origin)
+					body.bullet_hit(GRENADE_DAMAGE, body.global_transform.looking_at(global_transform.origin, Vector3(0,1,0)) )
 			
 			# This would be the perfect place to play a sound!
 		

--- a/Turret.gd
+++ b/Turret.gd
@@ -176,11 +176,11 @@ func fire_bullet():
 		node_raycast.force_raycast_update()
 		
 		# If the ray hit something, get its collider and see if it has the 'bullet_hit' method.
-		# If it does, then call it and pass the ray's collision point as the bullet collision point.
+		# If it does, then call it and pass the ray's global transform so we can tell which direction the bullet game from
 		if node_raycast.is_colliding():
 			var body = node_raycast.get_collider()
 			if body.has_method("bullet_hit"):
-				body.bullet_hit(TURRET_DAMAGE_RAYCAST, node_raycast.get_collision_point())
+				body.bullet_hit(TURRET_DAMAGE_RAYCAST, node_raycast.global_transform)
 		
 		# Remove the bullet from the turret
 		ammo_in_turret -= 1

--- a/Turret.tscn
+++ b/Turret.tscn
@@ -143,6 +143,8 @@ surfaces/4 = {
 
 [sub_resource type="CylinderMesh" id=4]
 
+custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
+flip_faces = false
 top_radius = 0.4
 bottom_radius = 1.4
 height = 2.0
@@ -160,6 +162,7 @@ flags_use_point_size = false
 flags_world_triplanar = false
 flags_fixed_size = false
 flags_albedo_tex_force_srgb = false
+flags_do_not_receive_shadows = false
 vertex_color_use_as_albedo = false
 vertex_color_is_srgb = false
 params_diffuse_mode = 0
@@ -265,6 +268,7 @@ flags_use_point_size = false
 flags_world_triplanar = false
 flags_fixed_size = false
 flags_albedo_tex_force_srgb = false
+flags_do_not_receive_shadows = false
 vertex_color_use_as_albedo = false
 vertex_color_is_srgb = false
 params_diffuse_mode = 0
@@ -309,6 +313,8 @@ _sections_unfolded = [ "Albedo" ]
 [sub_resource type="SphereMesh" id=11]
 
 material = SubResource( 10 )
+custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
+flip_faces = false
 radius = 0.2
 height = 0.5
 radial_segments = 6
@@ -316,14 +322,12 @@ rings = 3
 is_hemisphere = false
 
 [node name="Turret" type="Spatial" index="0"]
-
 script = ExtResource( 1 )
 use_raycast = false
 
 [node name="Base" type="Spatial" parent="." index="0"]
 
 [node name="Turret_Base" type="MeshInstance" parent="Base" index="0"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.273253 )
 layers = 1
 material_override = null
@@ -343,7 +347,6 @@ material/3 = null
 _sections_unfolded = [ "Transform" ]
 
 [node name="Static_Body" type="StaticBody" parent="Base" index="1"]
-
 editor/display_folded = true
 input_ray_pickable = true
 input_capture_on_drag = false
@@ -357,24 +360,20 @@ script = ExtResource( 6 )
 path_to_turret_root = NodePath("../..")
 
 [node name="Collision_Shape" type="CollisionShape" parent="Base/Static_Body" index="0"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.68306, 0.587342 )
 shape = SubResource( 2 )
 disabled = false
 
 [node name="Collision_Shape_2" type="CollisionShape" parent="Base/Static_Body" index="1"]
-
-transform = Transform( -4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 1.68306, 0.587342 )
+transform = Transform( -4.37114e-008, 0, -1, 0, 1, 0, 1, 0, -4.37114e-008, 0, 1.68306, 0.587342 )
 shape = SubResource( 2 )
 disabled = false
 
 [node name="Head" type="Spatial" parent="." index="1"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.75254, 0.549067 )
 _sections_unfolded = [ "Transform" ]
 
 [node name="Turret_Head" type="MeshInstance" parent="Head" index="0"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.00935364, 0.493907 )
 layers = 1
 material_override = null
@@ -395,8 +394,7 @@ material/4 = null
 _sections_unfolded = [ "Geometry", "Transform" ]
 
 [node name="Flash" type="MeshInstance" parent="Head" index="1"]
-
-transform = Transform( 0.6, 0, 0, 0, -2.62268e-08, -0.6, 0, 0.6, -2.62268e-08, 0, 3.69553, -6.75926 )
+transform = Transform( 0.6, 0, 0, 0, -2.62268e-008, -0.6, 0, 0.6, -2.62268e-008, 0, 3.69553, -6.75926 )
 layers = 1
 material_override = null
 cast_shadow = 1
@@ -412,8 +410,7 @@ material/0 = SubResource( 5 )
 _sections_unfolded = [ "material" ]
 
 [node name="Flash_2" type="MeshInstance" parent="Head" index="2"]
-
-transform = Transform( 0.6, 0, 0, 0, -2.62268e-08, -0.6, 0, 0.6, -2.62268e-08, 0, 2.65687, -6.38286 )
+transform = Transform( 0.6, 0, 0, 0, -2.62268e-008, -0.6, 0, 0.6, -2.62268e-008, 0, 2.65687, -6.38286 )
 layers = 1
 material_override = null
 cast_shadow = 1
@@ -429,7 +426,6 @@ material/0 = SubResource( 5 )
 _sections_unfolded = [ "Geometry", "Transform", "material" ]
 
 [node name="Ray_Cast" type="RayCast" parent="Head" index="3"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4.35444, -2.734 )
 enabled = false
 exclude_parent = true
@@ -437,11 +433,9 @@ cast_to = Vector3( 0, 0, -40 )
 collision_mask = 1
 
 [node name="Barrel_End" type="Spatial" parent="Head" index="4"]
-
-transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, 0, 4.22162, -11.5493 )
+transform = Transform( -1, 0, -1.50996e-007, 0, 1, 0, 1.50996e-007, 0, -1, 0, 4.22162, -11.5493 )
 
 [node name="Static_Body" type="StaticBody" parent="Head" index="5"]
-
 editor/display_folded = true
 input_ray_pickable = true
 input_capture_on_drag = false
@@ -455,19 +449,16 @@ script = ExtResource( 6 )
 path_to_turret_root = NodePath("../..")
 
 [node name="Collision_Shape" type="CollisionShape" parent="Head/Static_Body" index="0"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.43577, -3.32666 )
 shape = SubResource( 6 )
 disabled = false
 
 [node name="Collision_Shape_2" type="CollisionShape" parent="Head/Static_Body" index="1"]
-
 transform = Transform( 1, 0, 0, 0, 0.922934, 0.384959, 0, -0.384959, 0.922934, 0, 1.90657, 0.297366 )
 shape = SubResource( 7 )
 disabled = false
 
 [node name="Vision_Area" type="Area" parent="." index="2"]
-
 editor/display_folded = true
 input_ray_pickable = false
 input_capture_on_drag = false
@@ -491,13 +482,11 @@ reverb_bus_amount = 0.0
 reverb_bus_uniformity = 0.0
 
 [node name="Collision_Shape" type="CollisionShape" parent="Vision_Area" index="0"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7, 0 )
 shape = SubResource( 8 )
 disabled = false
 
 [node name="Smoke" type="Particles" parent="." index="3"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.85465, 0.50817 )
 layers = 1
 material_override = null
@@ -525,5 +514,4 @@ process_material = SubResource( 9 )
 draw_passes = 1
 draw_pass_1 = SubResource( 11 )
 _sections_unfolded = [ "Draw Passes", "Process Material", "Time" ]
-
 

--- a/Weapon_Knife.gd
+++ b/Weapon_Knife.gd
@@ -50,7 +50,7 @@ func fire_weapon():
 			continue
 		
 		if body.has_method("bullet_hit"):
-			body.bullet_hit(DAMAGE, area.global_transform.origin)
+			body.bullet_hit(DAMAGE, area.global_transform)
 
 
 func reload_weapon():

--- a/Weapon_Rifle.gd
+++ b/Weapon_Rifle.gd
@@ -51,7 +51,7 @@ func fire_weapon():
 		if body == player_node:
 			pass
 		elif body.has_method("bullet_hit"):
-			body.bullet_hit(DAMAGE, ray.get_collision_point())
+			body.bullet_hit(DAMAGE, ray.global_transform)
 	
 	# Remove the bullet from the mag
 	ammo_in_weapon -= 1


### PR DESCRIPTION
Changed how ``RigidBody_hit_test.gd works``. Now it takes rotation of the bullet into account, which gives the RigidBody nodes more realistic behavior and works from all angles.

Fixes [this issue](https://github.com/godotengine/godot-docs/issues/1485) in the Godot documentation repository.