### PR TITLE
Fixed clamping of camera

### DIFF
--- a/Player.gd
+++ b/Player.gd
@@ -727,18 +727,23 @@ func _input(event):
 		# Mouse rotation.
 		
 		# Rotate the camera holder (everything that needs to rotate on the X-axis) by the relative Y mouse motion.
-		rotation_helper.rotate_x(deg2rad(event.relative.y * MOUSE_SENSITIVITY))
+		var x_change_deg = event.relative.y * MOUSE_SENSITIVITY
+		
 		# Rotate the kinematic body on the Y axis by the relative X motion.
 		# We also need to multiply it by -1 because we're wanting to turn in the same direction as
 		# mouse motion in real life. If we physically move the mouse left, we want to turn to the left.
-		self.rotate_y(deg2rad(event.relative.x * MOUSE_SENSITIVITY * -1))
-		# ----------------------------------
-		
+		var y_change_deg = event.relative.x * MOUSE_SENSITIVITY * -1
+
 		# We need to clamp the rotation_helper's rotation so we cannot rotate ourselves upside down
 		# We need to do this every time we rotate so we cannot rotate upside down with mouse and/or joypad input
-		var camera_rot = rotation_helper.rotation_degrees
-		camera_rot.x = clamp(camera_rot.x, -70, 70)
-		rotation_helper.rotation_degrees = camera_rot
+		var curr_x_rot = rad2deg(rotation_helper.rotation.x)
+		if x_change_deg > 0:
+			x_change_deg = min(x_change_deg, 70 - curr_x_rot)
+		else:
+			x_change_deg = max(x_change_deg, -70 - curr_x_rot)
+
+		rotation_helper.rotate_x(deg2rad(x_change_deg))
+		self.rotate_y(deg2rad(y_change_deg))
 
 
 func fire_bullet():


### PR DESCRIPTION
This resolves #24. Before, when the camera was clamped after it was rotated, it could flip if the user looked up or down too fast.

This solution makes sure that the requested rotation is allowed before applying it. If it tries to go too far, it is reduced to the maximum value before it is used to rotate the camera.

I only changed minor parts of the comments, but I may need to go back and change some of them before this PR is accepted.